### PR TITLE
Add option to set custom redirect page

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -54,6 +54,22 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
         </div>
       </div>
       <div>
+        <p class="title1">Default redirect website</p>
+        <p class="subtitle1">You can customize where you will redirected after each attempt to visit a blocked site instead of the default screen. Empty value will be a new chrome tab.</p>
+        <table id="redirectTable">
+            <tr class="head">
+              <th class="table-checkbox">
+              </th>
+              <th>Website</th>
+              <th class="table-cross">Delete</th>
+            </tr>
+        </table>
+        <div>
+          <p class="title2">Set redirect website</p>
+          <input id="redirectInput" type="text" style="width: 100%;">
+        </div>
+      </div>
+      <div>
         <p class="title1">About</p>
         <p>This extension has been made in a couple of days from an idea I had when
           I saw my girlfriend on facebook instead of studying. It is open source

--- a/js/background.js
+++ b/js/background.js
@@ -85,7 +85,20 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
           if(details.frameId === 0 && urlContains(details.url, websites)){
             var id = details.tabId;
 
-            chrome.tabs.update(id, {"url": "html/message.html"});
+            storage.local.get(["redirectWebsite"], function(items) {
+              
+              if(items.redirectWebsite) {
+                if(!items.redirectWebsite.url.length) {
+                  chrome.tabs.remove(id, function(tab) {
+                    chrome.tabs.create({ } ,function() {})
+                  })
+                } else {
+                  chrome.tabs.update(id, {"url":  items.redirectWebsite.url});
+                }
+              } else {
+                chrome.tabs.update(id, {"url": "html/message.html"});
+              }
+            })
 
             /* update the number of blocked attempts */
             storage.local.get("blocked", function(item){

--- a/js/settings.js
+++ b/js/settings.js
@@ -56,7 +56,7 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
 
   /* Load the default and custom list from chrome storage */
   function loadWebsites(){
-    storage.local.get(["defaultWebsites", "customWebsites"], function(items){
+    storage.local.get(["defaultWebsites", "customWebsites", "redirectWebsite"], function(items){
       /* Default websites loading */
       if(items.defaultWebsites !== undefined){
         var defaults = items.defaultWebsites;
@@ -85,8 +85,16 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
           table.innerHTML += element;
         }
 
-        attachEvents();
       }
+
+
+      var table = document.getElementById("redirectTable");
+      table.innerHTML = tableHead;
+      if(items.redirectWebsite) {
+        var website = items.redirectWebsite;
+        table.innerHTML += fillTemplate(tableElementTemplate, {"id": "redirect0", "el": website.url, "checked": website.on ? "checked" : ""});
+      }
+      attachEvents();
     });
   }
 
@@ -140,6 +148,20 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
     }
   }
 
+
+
+  function setRedirectWebsite(e){
+    if(e.keyCode === 13){
+      var input = document.getElementById("redirectInput");
+
+
+      storage.local.set({"redirectWebsite": {url: input.value, on: true}}, function(){
+        loadWebsites();
+      });
+
+    }
+  }
+
   function deleteCustomWebsite(e){
     var id = this.parentElement.id.replace("custom", "");
 
@@ -157,11 +179,21 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
 
   function attachEvents(){
     /* Deleting event */
-    var crosses = document.getElementsByClassName("table-cross");
+    var crosses = document.querySelectorAll("#customTable .table-cross");
 
     /* Skip the first element because we don't want to affect the first line */
     for(var i = 1; i < crosses.length; i++){
       crosses.item(i).addEventListener("click", deleteCustomWebsite);
+    }
+
+
+    var redirect = document.querySelectorAll("#redirectTable .table-cross");
+    if(redirect && redirect[1]) {
+      redirect[1].addEventListener("click", () => {
+        storage.local.remove(["redirectWebsite"], function() {
+          loadWebsites();
+        });
+      })
     }
 
     /* Checking event */
@@ -180,5 +212,7 @@ along with Focus Mode.  If not, see <http://www.gnu.org/licenses/>.
 
   loadWebsites();
   document.getElementById("addingInput").addEventListener("keypress", addCustomWebsite);
+
+  document.getElementById("redirectInput").addEventListener("keypress", setRedirectWebsite);
 
 })();


### PR DESCRIPTION
Hello,
I've wanted to be able to automatically load preferred website upon block, it should work as expected.

I've actually mostly wanted to load my default new tab - which seemed to run into issues with it being blocked by an extension (possibly the extension I have on that page - TabText), so for empty string it discards tab and creates new tab, for me it works as I want, but losing tab history might not be desired.